### PR TITLE
Sensors.py: Fix padding in sensor_id

### DIFF
--- a/Database/Sensors.py
+++ b/Database/Sensors.py
@@ -559,7 +559,7 @@ class StatsMetaApp:
             if entry["selected"] and entry["import_id"]:
                 parts = []
                 # name field
-                parts.append(f"'{entry['import_id']:<{columns[0][1]}}'")
+                parts.append(f"'{entry['import_id']}'".ljust(columns[0][1]))
                 # numeric fields
                 vals = [
                     entry["id"],


### PR DESCRIPTION
Thanks for this useful tool! 

While using it to import historic data, I found that the generated SQL contains padding spaces inside the sensor name strings, which breaks the import SQL. 